### PR TITLE
Fix placeholders

### DIFF
--- a/Classes Vs Case Classes/Creation and Manipulation/task.md
+++ b/Classes Vs Case Classes/Creation and Manipulation/task.md
@@ -35,4 +35,4 @@ Let’s create some instances of `BankAccount` and `Note` and manipulate them.
 ## Exercise
 
 - Deposit `100` to the account.
-- Create a `c3` `Note` instance.
+- Create a `C3` `Note` instance.

--- a/Definitions and Evaluation/Naming Things 2/task-info.yaml
+++ b/Definitions and Evaluation/Naming Things 2/task-info.yaml
@@ -3,15 +3,6 @@ files:
 - name: src/DefinitionsAndEvaluation.scala
   visible: true
   placeholders:
-  - offset: 0
-    length: 6
-    placeholder_text: // TODO
-    dependency:
-      lesson: Definitions and Evaluation
-      task: Naming Things
-      file: src/DefinitionsAndEvaluation.scala
-      placeholder: 1
-      is_visible: false
   - offset: 123
     length: 14
     placeholder_text: // reuse the square method here

--- a/Definitions and Evaluation/Naming Things/task-info.yaml
+++ b/Definitions and Evaluation/Naming Things/task-info.yaml
@@ -3,7 +3,7 @@ files:
 - name: src/DefinitionsAndEvaluation.scala
   visible: true
   placeholders:
-  - offset: 0
+  - offset: 33
     length: 0
     placeholder_text: // Complete the method evaluating the area of a disk
   - offset: 68


### PR DESCRIPTION
In the `Definition and Evaluation` course, placeholders are overriding the class definition which fails the compilation.
This PR fixes that.

Just went through the course, great job!